### PR TITLE
Exit the process on successful download case

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -58,4 +58,5 @@ download(opts, function (err) {
     return process.exit(1)
   }
   log.info('install', 'Successfully installed prebuilt binary!')
+  process.exit(0)
 })


### PR DESCRIPTION
When I use the following install command in package.json as recommended in the documentation:
```
...
  "scripts": {
    "install": "prebuild-install || node-gyp rebuild"
  }
...

```
The prebuilt binary is properly downloaded, installed, but after that the installation process never returns. Is that expected? If not, would this patch be an acceptable fix?