### PR TITLE
tweak readme + update node versions + standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '9'
   - '8'
   - '7'
   - '6'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# prebuild-install [![Build Status](https://travis-ci.org/mafintosh/prebuild-install.svg?branch=master)](https://travis-ci.org/mafintosh/prebuild-install)
+# prebuild-install
 
-A command line tool for easily install prebuilds for multiple version of node/iojs on a specific platform.
+[![Build Status](https://travis-ci.org/prebuild/prebuild-install.svg?branch=master)](https://travis-ci.org/prebuild/prebuild-install)
+
+> A command line tool for easily install prebuilds for multiple version of node/iojs on a specific platform.
 
 `prebuild-install` supports installing prebuilt binaries from GitHub by default.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # prebuild-install
 
 [![Build Status](https://travis-ci.org/prebuild/prebuild-install.svg?branch=master)](https://travis-ci.org/prebuild/prebuild-install)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 > A command line tool for easily install prebuilds for multiple version of node/iojs on a specific platform.
 


### PR DESCRIPTION
Fixes broken travis badge and adds node 9 to travis. (I also enabled prebuild org on travis).