### PR TITLE
Fix download API crash when no logger specified

### DIFF
--- a/download.js
+++ b/download.js
@@ -3,7 +3,8 @@ var fs = require('fs')
 var get = require('simple-get')
 var pump = require('pump')
 var tfs = require('tar-fs')
-var noop = Object.assign({
+var extend = require('xtend')
+var noop = extend({
   http: function () {},
   silly: function () {}
 }, require('noop-logger'))

--- a/download.js
+++ b/download.js
@@ -3,7 +3,10 @@ var fs = require('fs')
 var get = require('simple-get')
 var pump = require('pump')
 var tfs = require('tar-fs')
-var noop = require('noop-logger')
+var noop = Object.assign({
+  http: function () {},
+  silly: function () {}
+}, require('noop-logger'))
 var zlib = require('zlib')
 var util = require('./util')
 var error = require('./error')

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -288,7 +288,6 @@ function getOpts () {
     nolocal: true,
     platform: process.platform,
     arch: process.arch,
-    path: __dirname,
-    log: {http: function (type, message) {}, info: function (type, message) {}}
+    path: __dirname
   }
 }


### PR DESCRIPTION
The noop logger doesn't have an http method. It also doesn't have a silly method, and this project doesn't do `log.silly()` anywhere, but I figured I'd add it too just to make sure all the `npmlog` methods have equivalents here.