### PR TITLE
Add --binary-name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ Change your package.json install script to:
 ...
 ```
 
+If your prebuild packages contain multiple `.node` files, use the `--binary-name`
+parameter to choose one to import:
+
+```
+...
+  "scripts": {
+    "install": "prebuild-install --binary-name native-module.node || node-gyp rebuild"
+  }
+...
+```
+
 ### Requirements
 
 You need to provide prebuilds made by [prebuild](https://github.com/mafintosh/prebuild)
@@ -31,6 +42,7 @@ prebuild-install [options]
   --runtime     -r  runtime     (Node runtime [node or electron] to build or install for, default is node)
   --path        -p  path        (make a prebuild-install here)
   --build-from-source           (skip prebuild download)
+  --binary-name                 (filename of the binary module to load when multiple binaries are present)
   --verbose                     (log verbosely)
   --libc                        (use provided libc rather than system default)
   --debug                       (set Debug or Release configuration)

--- a/download.js
+++ b/download.js
@@ -104,10 +104,6 @@ function downloadPrebuild (opts, cb) {
   function unpack () {
     var binaryName
 
-    var updateName = opts.updateName || function (entry) {
-      if (/\.node$/i.test(entry.name)) binaryName = entry.name
-    }
-
     log.info('unpacking @', cachedPrebuild)
 
     var options = {
@@ -115,7 +111,18 @@ function downloadPrebuild (opts, cb) {
       writable: true,
       hardlinkAsFilesFallback: true
     }
-    var extract = tfs.extract(opts.path, options).on('entry', updateName)
+
+    var extract = tfs.extract(opts.path, options)
+
+    if (opts['binary-name']) {
+      binaryName = opts['binary-name']
+    } else {
+      var updateName = opts.updateName || function (entry) {
+        if (/\.node$/i.test(entry.name)) binaryName = entry.name
+      }
+
+      extract.on('entry', updateName)
+    }
 
     pump(fs.createReadStream(cachedPrebuild), zlib.createGunzip(), extract,
     function (err) {

--- a/help.txt
+++ b/help.txt
@@ -6,6 +6,7 @@ prebuild-install [options]
   --path        -p  path        (make a prebuild-install here)
   --force                       (always use prebuilt binaries when available)
   --build-from-source           (skip prebuild download)
+  --binary-name                 (filename of the binary module to load when multiple binaries are present)
   --verbose                     (log verbosely)
   --libc                        (use provided libc rather than system default)
   --debug                       (set Debug or Release configuration)

--- a/rc.js
+++ b/rc.js
@@ -31,6 +31,7 @@ module.exports = function (pkg) {
     arch: pkgConf.arch || env.npm_config_arch || process.arch,
     libc: env.LIBC,
     platform: env.npm_config_platform || process.platform,
+    'binary-name': undefined,
     debug: false,
     force: false,
     verbose: false,


### PR DESCRIPTION
This change adds a new --binary-name parameter which allows the
user to select which binary file to load when the prebuilt package
contains more than one binary.