### PR TITLE
Add detection for non-glibc libc on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "devops"
   ],
   "dependencies": {
+    "detect-libc": "^1.0.3",
     "expand-template": "^1.0.2",
     "github-from-package": "0.0.0",
     "minimist": "^1.2.0",

--- a/rc.js
+++ b/rc.js
@@ -1,7 +1,10 @@
 var minimist = require('minimist')
 var getAbi = require('node-abi').getAbi
+var detectLibc = require('detect-libc')
 
 var env = process.env
+
+var libc = env.LIBC || (detectLibc.isNonGlibcLinux && detectLibc.family) || ''
 
 // Get `prebuild-install` arguments that were passed to the `npm` command
 if (env.npm_config_argv) {
@@ -29,7 +32,7 @@ module.exports = function (pkg) {
     target: pkgConf.target || env.npm_config_target || process.versions.node,
     runtime: pkgConf.runtime || env.npm_config_runtime || 'node',
     arch: pkgConf.arch || env.npm_config_arch || process.arch,
-    libc: env.LIBC,
+    libc: libc,
     platform: env.npm_config_platform || process.platform,
     debug: false,
     force: false,

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -13,7 +13,8 @@ test('custom config and aliases', function (t) {
     '--help',
     '--path ../some/other/path',
     '--target 1.4.10',
-    '--runtime electron'
+    '--runtime electron',
+    '--libc testlibc'
   ]
   runRc(t, args.join(' '), {}, function (rc) {
     t.equal(rc.arch, 'ARCH', 'correct arch')
@@ -32,6 +33,7 @@ test('custom config and aliases', function (t) {
     t.equal(rc.target, rc.t, 'target alias')
     t.equal(rc.runtime, 'electron', 'correct runtime')
     t.equal(rc.runtime, rc.r, 'runtime alias')
+    t.equal(rc.libc, 'testlibc', 'libc family')
     t.equal(rc.abi, '50', 'correct ABI')
     t.end()
   })


### PR DESCRIPTION
Hello, this PR is the "partner" commit of https://github.com/prebuild/prebuild/pull/180 to detect the libc family at install time.

The `detect-libc` dependency is already used by [node-pre-gyp](https://github.com/mapbox/node-pre-gyp/blob/f21830e2946d140b8b424b0f3acf4fb81eaa01e7/package.json#L31) for the same purpose.