### PR TITLE
Bumping node-abi version for node-webkit runtime support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "github-from-package": "0.0.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "node-abi": "^2.1.1",
+    "node-abi": "^2.2.0",
     "noop-logger": "^0.1.1",
     "npmlog": "^4.0.1",
     "os-homedir": "^1.0.1",


### PR DESCRIPTION
Follow-up from https://github.com/prebuild/prebuild/pull/203 and https://github.com/lgeiger/node-abi/pull/34#issuecomment-360634948.