### PR TITLE
fix: download prebuilt binaries when installing with pnpm

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,11 +3,11 @@
 var path = require('path')
 var log = require('npmlog')
 var fs = require('fs')
+var whichPmRuns = require('which-pm-runs')
 
 var pkg = require(path.resolve('package.json'))
 var rc = require('./rc')(pkg)
 var download = require('./download')
-var util = require('./util')
 
 var prebuildClientVersion = require('./package.json').version
 if (rc.version) {
@@ -36,9 +36,10 @@ log.info('begin', 'Prebuild-install version', prebuildClientVersion)
 
 var opts = Object.assign({}, rc, {pkg: pkg, log: log})
 
-var execPath = process.env.npm_execpath || process.env.NPM_CLI_JS
+var pm = whichPmRuns()
+var isNpm = !pm || pm.name === 'npm'
 
-if (util.isYarnPath(execPath) && /node_modules/.test(process.cwd())) {
+if (!isNpm && /node_modules/.test(process.cwd())) {
   // From yarn repository
 } else if (opts.force) {
   log.warn('install', 'prebuilt binaries enforced with --force!')

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "rc": "^1.1.6",
     "simple-get": "^2.7.0",
     "tar-fs": "^1.13.0",
-    "tunnel-agent": "^0.6.0"
+    "tunnel-agent": "^0.6.0",
+    "which-pm-runs": "^1.0.0"
   },
   "devDependencies": {
     "a-native-module": "^1.0.0",

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -190,12 +190,3 @@ test('getDownloadUrl() expands template to correct values', function (t) {
   t.equal(url3, url2, 'scope does not matter for download url')
   t.end()
 })
-
-test('isYarnPath(): returns correct value', function (t) {
-  var yarn = util.isYarnPath
-  t.equal(yarn(null), false)
-  t.equal(yarn(undefined), false)
-  t.equal(yarn('/usr/local/lib/node_modules/npm/bin/npm-cli.js'), false)
-  t.equal(yarn('/usr/local/opt/yarn/libexec/lib/node_modules/yarn/bin/yarn.js'), true)
-  t.end()
-})

--- a/util.js
+++ b/util.js
@@ -80,10 +80,6 @@ function localPrebuild (url) {
   return path.join('prebuilds', path.basename(url))
 }
 
-function isYarnPath (execPath) {
-  return execPath ? /^yarn/.test(path.basename(execPath)) : false
-}
-
 exports.getDownloadUrl = getDownloadUrl
 exports.urlTemplate = urlTemplate
 exports.cachedPrebuild = cachedPrebuild
@@ -91,4 +87,3 @@ exports.localPrebuild = localPrebuild
 exports.prebuildCache = prebuildCache
 exports.npmCache = npmCache
 exports.tempFile = tempFile
-exports.isYarnPath = isYarnPath


### PR DESCRIPTION
Like Yarn, [pnpm](https://github.com/pnpm/pnpm) does not add a `_from` field to the `package.json` files of the installed dependencies. So pnpm needs the same workaround as Yarn