### PR TITLE
Shortened filename in cache

### DIFF
--- a/util.js
+++ b/util.js
@@ -1,6 +1,7 @@
 var path = require('path')
 var github = require('github-from-package')
 var home = require('os-homedir')
+var crypto = require('crypto')
 var expandTemplate = require('expand-template')()
 
 function getDownloadUrl (opts) {
@@ -68,7 +69,8 @@ function trimSlashes (str) {
 }
 
 function cachedPrebuild (url) {
-  return path.join(prebuildCache(), url.replace(/[^a-zA-Z0-9.]+/g, '-'))
+  var digest = crypto.createHash('md5').update(url).digest('hex').slice(0, 6)
+  return path.join(prebuildCache(), digest + '-' + path.basename(url).replace(/[^a-zA-Z0-9.]+/g, '-'))
 }
 
 function npmCache () {


### PR DESCRIPTION
This implements Option 2 from https://github.com/prebuild/prebuild-install/issues/77.

The test file's name changes from 
```
https-github.com-ralphtheninja-a-native-module-releases-download-v1.0.0-a-native-module-v1.0.0-node-v59-win32-x64.tar.gz
```
to
```
36772a-a-native-module-v1.0.0-node-v59-win32-x64.tar.gz
```

This is mostly for continuing the discussion from #77 -- let me know if you'd rather have what I outlined in Option 1 or something else entirely.

It might also make sense to actually verify that the filename is shorter than 140 chars and truncate part of it if that's the case.