### PR TITLE
Skipping require-test after download if process arch is not same as downloaded

### DIFF
--- a/download.js
+++ b/download.js
@@ -97,7 +97,7 @@ function downloadPrebuild (downloadUrl, opts, cb) {
         }
         log.info('unpack', 'resolved to ' + resolved)
 
-        if (opts.runtime === 'node' && opts.platform === process.platform && opts.abi === process.versions.modules) {
+        if (opts.runtime === 'node' && opts.platform === process.platform && opts.abi === process.versions.modules && opts.arch === process.arch) {
           try {
             require(resolved)
           } catch (err) {


### PR DESCRIPTION
Encountered an issue when trying to download prebuild binary for a certain architecture, while doing it using node with a different one (i.e. npm install --arch=ia32 but node is x64).
If platforms are different, there's no point in requiring the downloaded module, as it will throw anyway