### PR TITLE
Bump expand-template to correct licensing details

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "detect-libc": "^1.0.3",
-    "expand-template": "^1.0.2",
+    "expand-template": "^2.0.3",
     "github-from-package": "0.0.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Hello, this change involves a major version increment of `expand-template` but I think the bump is only due to its Node 6 minimum that now matches this module. All the existing tests continue to pass.

The main benefit of upgrading is to pick up the correct licensing details from the latest version of this module.