### PR TITLE
add workaround to block preinstall for known issue with Electron 4.0.x

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -20,6 +20,12 @@ if (rc.version) {
 
 if (rc.path) process.chdir(rc.path)
 
+if (rc.runtime === 'electron' && rc.target[0] === '4' && rc.abi === '64') {
+  log.error(`Electron version ${rc.target} found - skipping prebuild-install work due to known ABI issue`)
+  log.error('More information about this issue can be found at https://github.com/lgeiger/node-abi/issues/54')
+  process.exit(1)
+}
+
 if (!fs.existsSync('package.json')) {
   log.error('setup', 'No package.json found. Aborting...')
   process.exit(1)


### PR DESCRIPTION
I'm a maintainer on [`keytar`](https://github.com/atom/node-keytar) and had to deal with the Electron 3/4 transition which had a known ABI issue that impacted native modules, discussed here https://github.com/lgeiger/node-abi/issues/54. We were able to workaround it by blocking clients from trying to download these packages, and I thought I'd upstream this fix to see if you were interested in making this available more broadly for anyone else who happens to stumble into it.

In a nutshell, this setup of `prebuild` packages should not be used if they were created:

 - `electron` runtime
 - a target between `4.0.0` and `4.0.3` (inclusive)
 - ABI 64 (Node 4 now uses 69 for it's ABI)

The patch to `node-abi` to support this new ABI is now available, so that future prebuild installs will avoid all this drama: https://github.com/lgeiger/node-abi/commit/9e4c1a63e63f8994cc2f5e3efee43785c9eb1c8f