### PR TITLE
bump to latest node-abi (Node 12/Electron 5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "napi-build-utils": "^1.0.1",
-    "node-abi": "^2.7.0",
+    "node-abi": "^2.8.0",
     "noop-logger": "^0.1.1",
     "npmlog": "^4.0.1",
     "os-homedir": "^1.0.1",


### PR DESCRIPTION
https://github.com/lgeiger/node-abi/pull/62 adds support for detecting Electron 5 and Node 12