### PR TITLE
Fix bug with propName containing special characters

### DIFF
--- a/util.js
+++ b/util.js
@@ -61,7 +61,7 @@ function urlTemplate (opts) {
 }
 
 function getHostMirrorUrl (opts) {
-  var propName = 'npm_config_' + (opts.pkg.name || '').replace(/-/g, '_') + '_binary_host'
+  var propName = 'npm_config_' + (opts.pkg.name || '').replace(/[^a-zA-Z0-9]/g, '_') + '_binary_host'
   return process.env[propName] || process.env[propName + '_mirror']
 }
 


### PR DESCRIPTION
Fixed a problem in which environment variables could not be read  when the package name included special characters.

e.g.,
When using config `npm_config_@serialport/bindings_binary_host` to use custom binaries, It was replaced to `npm_config__serialport_bindings_binary_host` in `process.env`. (All special characters should be replaced to `_`.)