### PR TITLE
Ensure --verbose flag is passed through to rc options

### DIFF
--- a/rc.js
+++ b/rc.js
@@ -9,7 +9,7 @@ var libc = env.LIBC || (detectLibc.isNonGlibcLinux && detectLibc.family) || ''
 
 // Get `prebuild-install` arguments that were passed to the `npm` command
 if (env.npm_config_argv) {
-  var npmargs = ['prebuild', 'compile', 'build-from-source', 'debug']
+  var npmargs = ['prebuild', 'compile', 'build-from-source', 'debug', 'verbose']
   try {
     var npmArgv = JSON.parse(env.npm_config_argv).cooked
     for (var i = 0; i < npmargs.length; ++i) {

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -48,7 +48,8 @@ test('npm args are passed on from npm environment into rc', function (t) {
         '--build-from-source',
         '--download',
         'https://foo.bar',
-        '--debug'
+        '--debug',
+        '--verbose'
       ]
     })
   }
@@ -56,6 +57,7 @@ test('npm args are passed on from npm environment into rc', function (t) {
     t.equal(rc['build-from-source'], true, '--build-from-source works')
     t.equal(rc.compile, true, 'compile should be true')
     t.equal(rc.debug, true, 'debug should be true')
+    t.equal(rc.verbose, true, 'verbose should be true')
     t.equal(rc.download, 'https://foo.bar', 'download is set')
     t.end()
   })


### PR DESCRIPTION
This change adds support to detect the `yarn --verbose ...` flag and pass it through to `rc`, thus enabling verbose logging when requested.

This is required for `yarn` as it sets `npm_config_argv` but does not set `npm_config_loglevel` - see https://github.com/yarnpkg/yarn/issues/2472