### PR TITLE
Update mkdirp to latest version

### DIFF
--- a/download.js
+++ b/download.js
@@ -43,7 +43,7 @@ function downloadPrebuild (downloadUrl, opts, cb) {
         if (err) return onerror(err)
         log.http(res.statusCode, downloadUrl)
         if (res.statusCode !== 200) return onerror()
-        mkdirp(util.prebuildCache(), function () {
+        mkdirp(util.prebuildCache()).then(function () {
           log.info('downloading to @', tempFile)
           pump(res, fs.createWriteStream(tempFile), function (err) {
             if (err) return onerror(err)
@@ -122,7 +122,7 @@ function downloadPrebuild (downloadUrl, opts, cb) {
 
     function makeNpmCacheDir () {
       log.info('npm cache directory missing, creating it...')
-      mkdirp(cacheFolder, cb)
+      mkdirp(cacheFolder).then(cb)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "expand-template": "^2.0.3",
     "github-from-package": "0.0.0",
     "minimist": "^1.2.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.3",
     "napi-build-utils": "^1.0.1",
     "node-abi": "^2.7.0",
     "noop-logger": "^0.1.1",


### PR DESCRIPTION
Current `mkdirp` version is using `minimist` 0.0.8, which has a security [vulnerability](https://snyk.io/vuln/SNYK-JS-MINIMIST-559764).
`mkdirp` > 1.00 doesn't use `minimist` anymore so upgarding will resolve this issue.