### PR TITLE
Updates minimist to 1.2.3 to resolve dependency vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "detect-libc": "^1.0.3",
     "expand-template": "^2.0.3",
     "github-from-package": "0.0.0",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.3",
     "mkdirp": "^0.5.1",
     "napi-build-utils": "^1.0.1",
     "node-abi": "^2.7.0",


### PR DESCRIPTION
I had a project that received a GitHub alert based on a [minimist prototype pollution vulnerability reported to NPM](https://github.com/angular/angular/issues/36104), instructing to update to 1.2.3 ([more details here](https://snyk.io/vuln/SNYK-JS-MINIMIST-559764)). One of the dependencies using 1.2.0 was prebuild-install (depended on via serialport). As with https://github.com/angular/angular/issues/36104, I was able to fix it with `"resolutions": { "minimist": "^1.2.3" }`.

While this is a minor upgrade, I cannot easily verify the result because 30/33 tape tests fail on my system both with and without 1.2.3. Happy to go through those steps if other configuration is required.