### PR TITLE
Breaking: remove --compile and --prebuild options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ prebuild-install [options]
 
 When `prebuild-install` is run via an `npm` script, options
 `--build-from-source`, `--debug`, `--download`, `--target`, `--runtime`, `--arch` and `--platform` may be passed through via
-arguments given to the `npm` command. Alternatively you can set environment variables `npm_config_platform`, `npm_config_arch`, `npm_config_target` and `npm_config_runtime`.
+arguments given to the `npm` command. Alternatively you can set environment variables `npm_config_build_from_source=true`, `npm_config_platform`, `npm_config_arch`, `npm_config_target` and `npm_config_runtime`.
 
 ### Private Repositories
 

--- a/bin.js
+++ b/bin.js
@@ -54,7 +54,7 @@ if (!isNpm && /node_modules/.test(process.cwd())) {
 } else if (origin && origin.length > 4 && origin.substr(0, 4) === 'git+') {
   log.info('install', 'installing from git repository, skipping download.')
   process.exit(1)
-} else if (opts.compile === true || opts.prebuild === false) {
+} else if (opts.buildFromSource) {
   log.info('install', '--build-from-source specified, not attempting download.')
   process.exit(1)
 }

--- a/rc.js
+++ b/rc.js
@@ -9,9 +9,7 @@ var libc = env.LIBC || (detectLibc.isNonGlibcLinux && detectLibc.family) || ''
 // Get the configuration
 module.exports = function (pkg) {
   var pkgConf = pkg.config || {}
-
-  // TODO: remove compile and prebuild aliases?
-  var buildFromSource = env.npm_config_build_from_source || env.npm_config_compile
+  var buildFromSource = env.npm_config_build_from_source
 
   var rc = require('rc')('prebuild-install', {
     target: pkgConf.target || env.npm_config_target || process.versions.node,
@@ -22,8 +20,7 @@ module.exports = function (pkg) {
     debug: env.npm_config_debug === 'true',
     force: false,
     verbose: env.npm_config_verbose === 'true',
-    prebuild: env.npm_config_prebuild !== '',
-    compile: buildFromSource === pkg.name || buildFromSource === 'true',
+    buildFromSource: buildFromSource === pkg.name || buildFromSource === 'true',
     path: '.',
     proxy: env.npm_config_proxy || env['http_proxy'] || env['HTTP_PROXY'],
     'https-proxy': env.npm_config_https_proxy || env['https_proxy'] || env['HTTPS_PROXY'],
@@ -39,8 +36,7 @@ module.exports = function (pkg) {
       path: 'p',
       version: 'v',
       download: 'd',
-      'build-from-source': 'compile',
-      compile: 'c',
+      buildFromSource: 'build-from-source',
       token: 'T'
     }
   }))

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -55,18 +55,10 @@ test('npm args are passed on from npm environment into rc', function (t) {
   ].join(' ')
 
   runRc(t, args, {}, function (rc) {
-    t.equal(rc.compile, true, 'compile should be true')
+    t.equal(rc.buildFromSource, true, 'buildFromSource should be true')
     t.equal(rc.debug, true, 'debug should be true')
     t.equal(rc.verbose, true, 'verbose should be true')
     t.equal(rc.download, 'https://foo.bar', 'download is set')
-    t.equal(rc.prebuild, true, 'prebuild is true')
-    t.end()
-  })
-})
-
-test('negative npm args are passed on from npm environment into rc', function (t) {
-  runRc(t, '--no-prebuild', {}, function (rc) {
-    t.equal(rc.prebuild, false, 'prebuild is false')
     t.end()
   })
 })
@@ -89,7 +81,7 @@ test('npm_config_* are passed on from environment into rc', function (t) {
     t.equal(rc.target, '1.4.0', 'target is set')
     t.equal(rc.runtime, 'electron', 'runtime is set')
     t.equal(rc.platform, 'PLATFORM', 'platform is set')
-    t.equal(rc.compile, true, 'build-from-source is set')
+    t.equal(rc.buildFromSource, true, 'build-from-source is set')
     t.end()
   })
 })


### PR DESCRIPTION
In favor of `--build-from-source` which is a common option among build tools (`node-gyp-build`, `node-pre-gyp`). The `--compile` option was an alias and `--prebuild` is the default behavior anyway.