### PR TITLE
Fix: force, buildFromSource cli opts are ignored in yarn

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -2,7 +2,6 @@
 
 var path = require('path')
 var fs = require('fs')
-var whichPmRuns = require('which-pm-runs')
 var napi = require('napi-build-utils')
 
 var pkg = require(path.resolve('package.json'))
@@ -42,13 +41,9 @@ var opts = Object.assign({}, rc, { pkg: pkg, log: log })
 
 if (napi.isNapiRuntime(rc.runtime)) napi.logUnsupportedVersion(rc.target, log)
 
-var pm = whichPmRuns()
-var isNpm = !pm || pm.name === 'npm'
 var origin = util.packageOrigin(process.env, pkg)
 
-if (!isNpm && /node_modules/.test(process.cwd())) {
-  // From yarn repository
-} else if (opts.force) {
+if (opts.force) {
   log.warn('install', 'prebuilt binaries enforced with --force!')
   log.warn('install', 'prebuilt binaries may be out of date!')
 } else if (origin && origin.length > 4 && origin.substr(0, 4) === 'git+') {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "rc": "^1.2.7",
     "simple-get": "^3.0.3",
     "tar-fs": "^2.0.0",
-    "tunnel-agent": "^0.6.0",
-    "which-pm-runs": "^1.0.0"
+    "tunnel-agent": "^0.6.0"
   },
   "devDependencies": {
     "a-native-module": "^1.0.0",


### PR DESCRIPTION
The issue comes from this changes 4 years ago which fixed the issue that sources were always compiling when used in yarn: https://github.com/prebuild/prebuild-install/commit/e9065dd0e1c090fd4966496091fc1f27b074fadd

This fix seems irrelevant by now, when one looks at the code paths. It also blocks the usage of the force and buildFromSource options. It seems safe to simply remove the check altogether. I have verified that doing so makes `prebuild-install` correctly download or build from source when explicitly told so, using yarn.

Co-authored-by: Benjamin Pasero <benjpas@microsoft.com>
Fixes: https://github.com/prebuild/prebuild-install/issues/139