### PR TITLE
fixes empty --tag-prefix

### DIFF
--- a/util.js
+++ b/util.js
@@ -23,7 +23,7 @@ function getDownloadUrl (opts) {
     libc: opts.libc || process.env.LIBC || '',
     configuration: (opts.debug ? 'Debug' : 'Release'),
     module_name: opts.pkg.binary && opts.pkg.binary.module_name,
-    tag_prefix: opts['tag-prefix'] || 'v'
+    tag_prefix: opts['tag-prefix']
   })
 }
 


### PR DESCRIPTION
This check is superfluous. The default is set in `rc.js`. If we want to be type safe for `expandTemplate()` we can add a type check if we want to but I think it is not necessary.

fixes #141 