### PR TITLE
fix: Support URL-safe strings in scoped packages

### DIFF
--- a/test/util-test.js
+++ b/test/util-test.js
@@ -188,6 +188,22 @@ test('getDownloadUrl() expands template to correct values', function (t) {
   }
   var url3 = util.getDownloadUrl(o3)
   t.equal(url3, url2, 'scope does not matter for download url')
+  var o4 = {
+    pkg: {
+      name: '@scope-with.special~chars_/a-native-module',
+      version: 'x.y.z+beta77',
+      binary: {
+        host: 'https://foo.com',
+        module_name: 'a-native-module-bindings',
+        package_name: '{name}-{package_name}-{version}-{major}-{minor}-{patch}-{build}-{abi}-{node_abi}-{platform}-{arch}-{configuration}-{module_name}'
+      }
+    },
+    platform: 'coolplatform',
+    arch: 'futureplatform',
+    debug: true
+  }
+  var url4 = util.getDownloadUrl(o4)
+  t.equal(url4, url2, 'scope with special characters does not matter for download url')
   t.end()
 })
 

--- a/util.js
+++ b/util.js
@@ -5,7 +5,7 @@ var crypto = require('crypto')
 var expandTemplate = require('expand-template')()
 
 function getDownloadUrl (opts) {
-  var pkgName = opts.pkg.name.replace(/^@\w+\//, '')
+  var pkgName = opts.pkg.name.replace(/^@[a-zA-Z0-9_\-.~]+\//, '')
   return expandTemplate(urlTemplate(opts), {
     name: pkgName,
     package_name: pkgName,


### PR DESCRIPTION
Fixes #147 and adds support for scoped packages with URL-safe names.