### PR TITLE
Move auth token to header instead of query param

### DIFF
--- a/download.js
+++ b/download.js
@@ -43,10 +43,10 @@ function downloadPrebuild (downloadUrl, opts, cb) {
         var reqOpts = proxy({ url: downloadUrl }, opts)
 
         if (opts.token) {
-          reqOpts.url += '?access_token=' + opts.token
           reqOpts.headers = {
             'User-Agent': 'simple-get',
-            Accept: 'application/octet-stream'
+            Accept: 'application/octet-stream',
+            Authorization: 'token ' + opts.token
           }
         }
 

--- a/test/asset-test.js
+++ b/test/asset-test.js
@@ -33,13 +33,12 @@ nock('https://api.github.com:443', {
 })
   .persist()
   .get(function (uri) {
-    return /\/repos\/ralphtheninja\/a-native-module\/releases\/assets\/\d*\?access_token=TOKEN/g.test(uri)
+    return /\/repos\/ralphtheninja\/a-native-module\/releases\/assets\/\d*/g.test(uri)
   })
   .reply(302, undefined, {
     Location: function (req, res, body) {
       var assetId = req.path
         .replace('/repos/ralphtheninja/a-native-module/releases/assets/', '')
-        .replace('?access_token=TOKEN', '')
 
       for (var release of releases) {
         for (var asset of release.assets) {
@@ -85,7 +84,7 @@ test('downloading from GitHub with token', function (t) {
     var _request = https.request
     https.request = function (req) {
       https.request = _request
-      t.equal('https://' + req.hostname + req.path, downloadUrl + '?access_token=' + opts.token, 'correct url')
+      t.equal('https://' + req.hostname + req.path, downloadUrl, 'correct url')
       return _request.apply(https, arguments)
     }
 


### PR DESCRIPTION
As mentioned in issue #121 Github will deprecate auth via query param, so we move this to http header.

Read more about Github's decision to deprecate [here](https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/).