### PR TITLE
deps: update node-abi so that electron 14+ get correct node-abi

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [6, 8, 10, 12, 14, 16]
+        node: [10, 12, 14, 16]
         arch: [x64]
         include:
           - os: windows-latest

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "minimist": "^1.2.3",
     "mkdirp-classic": "^0.5.3",
     "napi-build-utils": "^1.0.1",
-    "node-abi": "^2.21.0",
+    "node-abi": "^3.3.0",
     "npmlog": "^4.0.1",
     "pump": "^3.0.0",
     "rc": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
   },
   "homepage": "https://github.com/prebuild/prebuild-install",
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
https://github.com/electron/node-abi/issues/113 was fixed in 3.3.0
and is affecting electron 14+

With the current node-abi prebuild-install will download ABI 89 for
electron 14 and 15 and then modules will fail to load as electron 14
has ABI 97 and electon 15 has ABI 98 in reality.