### PR TITLE
Upgrade to version 2 of detect-libc

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "napi"
   ],
   "dependencies": {
-    "detect-libc": "^1.0.3",
+    "detect-libc": "^2.0.0",
     "expand-template": "^2.0.3",
     "github-from-package": "0.0.0",
     "minimist": "^1.2.3",

--- a/rc.js
+++ b/rc.js
@@ -5,7 +5,7 @@ const detectLibc = require('detect-libc')
 const napi = require('napi-build-utils')
 
 const env = process.env
-const libc = env.LIBC || (detectLibc.isNonGlibcLinux && detectLibc.family) || ''
+const libc = env.LIBC || (detectLibc.isNonGlibcLinuxSync() && detectLibc.familySync()) || ''
 
 // Get the configuration
 module.exports = function (pkg) {


### PR DESCRIPTION
Hi, the latest [detect-libc](https://www.npmjs.com/package/detect-libc) has been modernised to use the non-blocking Node.js Report API where available (Node.js >= 12), falling back to use an efficient single child process with older versions.

It's a major version bump for detect-lib as it drops support for versions of Node.js < 8. Given prebuild-install already requires >= 10 this PR should OK to include in a patch release.

There's an extensive integration test suite, e.g. https://github.com/lovell/detect-libc/actions/runs/1717414863

Should anyone be interested in the background to this, please see https://github.com/lovell/detect-libc/issues/14