### PR TITLE
Allow setting libc to glibc on non-glibc platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,13 @@ prebuild-install [options]
   --version                     (print prebuild-install version and exit)
 ```
 
-When `prebuild-install` is run via an `npm` script, options `--build-from-source`, `--debug`, `--download`, `--target`, `--runtime`, `--arch` and `--platform` may be passed through via arguments given to the `npm` command.
+When `prebuild-install` is run via an `npm` script, options `--build-from-source`, `--debug`, `--download`, `--target`, `--runtime`, `--arch` `--platform` and `--libc` may be passed through via arguments given to the `npm` command.
 
-Alternatively you can set environment variables `npm_config_build_from_source=true`, `npm_config_platform`, `npm_config_arch`, `npm_config_target` and `npm_config_runtime`.
+Alternatively you can set environment variables `npm_config_build_from_source=true`, `npm_config_platform`, `npm_config_arch`, `npm_config_target` `npm_config_runtime` and `npm_config_libc`.
+
+### Libc
+
+On non-glibc Linux platforms, the Libc name is appended to platform name. For example, musl-based environments are called `linuxmusl`. If `--libc=glibc` is passed as option, glibc is discarded and platform is called as just `linux`. This can be used for example to build cross-platform packages on Alpine Linux.
 
 ### Private Repositories
 

--- a/rc.js
+++ b/rc.js
@@ -5,7 +5,9 @@ const detectLibc = require('detect-libc')
 const napi = require('napi-build-utils')
 
 const env = process.env
-const libc = env.LIBC || (detectLibc.isNonGlibcLinuxSync() && detectLibc.familySync()) || ''
+
+const libc = env.LIBC || process.env.npm_config_libc ||
+  (detectLibc.isNonGlibcLinuxSync() && detectLibc.familySync()) || ''
 
 // Get the configuration
 module.exports = function (pkg) {
@@ -50,6 +52,8 @@ module.exports = function (pkg) {
   }
 
   rc.abi = napi.isNapiRuntime(rc.runtime) ? rc.target : getAbi(rc.target, rc.runtime)
+
+  rc.libc = rc.libc === detectLibc.GLIBC ? '' : rc.libc
 
   return rc
 }

--- a/rc.js
+++ b/rc.js
@@ -53,7 +53,7 @@ module.exports = function (pkg) {
 
   rc.abi = napi.isNapiRuntime(rc.runtime) ? rc.target : getAbi(rc.target, rc.runtime)
 
-  rc.libc = rc.libc === detectLibc.GLIBC ? '' : rc.libc
+  rc.libc = rc.platform !== 'linux' || rc.libc === detectLibc.GLIBC ? '' : rc.libc
 
   return rc
 }

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -71,7 +71,8 @@ test('npm_config_* are passed on from environment into rc', function (t) {
     npm_config_target: '1.4.0',
     npm_config_runtime: 'electron',
     npm_config_platform: 'PLATFORM',
-    npm_config_build_from_source: 'true'
+    npm_config_build_from_source: 'true',
+    npm_config_libc: 'testlibc'
   }
   runRc(t, '', env, function (rc) {
     t.equal(rc.proxy, 'http://localhost/', 'proxy is set')
@@ -81,6 +82,7 @@ test('npm_config_* are passed on from environment into rc', function (t) {
     t.equal(rc.runtime, 'electron', 'runtime is set')
     t.equal(rc.platform, 'PLATFORM', 'platform is set')
     t.equal(rc.buildFromSource, true, 'build-from-source is set')
+    t.equal(rc.libc, 'testlibc', 'libc is set')
     t.end()
   })
 })
@@ -111,6 +113,16 @@ test('using --tag-prefix will set the tag prefix', function (t) {
   const args = ['--tag-prefix @scoped/package@']
   runRc(t, args.join(' '), {}, function (rc) {
     t.equal(rc['tag-prefix'], '@scoped/package@', 'tag prefix should be set')
+    t.end()
+  })
+})
+
+test('libc glibc is passed as empty', function (t) {
+  const args = [
+    '--libc glibc'
+  ]
+  runRc(t, args.join(' '), {}, function (rc, tmp) {
+    t.equal(rc.libc, '', 'libc family')
     t.end()
   })
 })

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -16,7 +16,6 @@ test('custom config and aliases', function (t) {
     '--path ../some/other/path',
     '--target 1.4.10',
     '--runtime electron',
-    '--libc testlibc',
     '--token TOKEN'
   ]
   runRc(t, args.join(' '), {}, function (rc, tmp) {
@@ -35,7 +34,6 @@ test('custom config and aliases', function (t) {
     t.equal(rc.target, rc.t, 'target alias')
     t.equal(rc.runtime, 'electron', 'correct runtime')
     t.equal(rc.runtime, rc.r, 'runtime alias')
-    t.equal(rc.libc, 'testlibc', 'libc family')
     t.equal(rc.abi, '50', 'correct ABI')
     t.equal(rc.token, 'TOKEN', 'correct token')
     t.equal(rc['tag-prefix'], 'v', 'correct default tag prefix')
@@ -70,7 +68,7 @@ test('npm_config_* are passed on from environment into rc', function (t) {
     npm_config_local_address: '127.0.0.1',
     npm_config_target: '1.4.0',
     npm_config_runtime: 'electron',
-    npm_config_platform: 'PLATFORM',
+    npm_config_platform: 'linux',
     npm_config_build_from_source: 'true',
     npm_config_libc: 'testlibc'
   }
@@ -80,7 +78,7 @@ test('npm_config_* are passed on from environment into rc', function (t) {
     t.equal(rc['local-address'], '127.0.0.1', 'local-address is set')
     t.equal(rc.target, '1.4.0', 'target is set')
     t.equal(rc.runtime, 'electron', 'runtime is set')
-    t.equal(rc.platform, 'PLATFORM', 'platform is set')
+    t.equal(rc.platform, 'linux', 'platform is set')
     t.equal(rc.buildFromSource, true, 'build-from-source is set')
     t.equal(rc.libc, 'testlibc', 'libc is set')
     t.end()
@@ -117,12 +115,35 @@ test('using --tag-prefix will set the tag prefix', function (t) {
   })
 })
 
+test('libc works on linux platform', function (t) {
+  const args = [
+    '--libc musl --platform linux'
+  ]
+  runRc(t, args.join(' '), {}, function (rc, tmp) {
+    t.equal(rc.libc, 'musl', 'libc family')
+    t.equal(rc.platform, 'linux', 'platform')
+    t.end()
+  })
+})
+
 test('libc glibc is passed as empty', function (t) {
   const args = [
-    '--libc glibc'
+    '--libc glibc --platform linux'
   ]
   runRc(t, args.join(' '), {}, function (rc, tmp) {
     t.equal(rc.libc, '', 'libc family')
+    t.equal(rc.platform, 'linux', 'platform')
+    t.end()
+  })
+})
+
+test('libc is discarded on non-linux platform', function (t) {
+  const args = [
+    '--libc musl --platform windows'
+  ]
+  runRc(t, args.join(' '), {}, function (rc, tmp) {
+    t.equal(rc.libc, '', 'libc family')
+    t.equal(rc.platform, 'windows', 'platform')
     t.end()
   })
 })

--- a/util.js
+++ b/util.js
@@ -20,7 +20,7 @@ function getDownloadUrl (opts) {
     runtime: opts.runtime || 'node',
     platform: opts.platform,
     arch: opts.arch,
-    libc: opts.libc || process.env.LIBC || '',
+    libc: opts.libc || '',
     configuration: (opts.debug ? 'Debug' : 'Release'),
     module_name: opts.pkg.binary && opts.pkg.binary.module_name,
     tag_prefix: opts['tag-prefix']


### PR DESCRIPTION
# Issue

Option `--libc` can be used to download musl packages on glibc and other platforms, but cannot be used to download glibc packages on musl platforms. In other words, I can pass `--libc=musl` or `--platform=linuxmusl` on any platform to install prebuild linuxmusl packages for cross-platform target.

On the other hand, if I pass `--platform=linux` on Alpine Linux, `linuxmusl` packages are still downloaded. If I pass `--libc=glibc`, it tries to download `linuxglibc` packages that don't exist. This effectively prevents building cross-platform packages for glibc Linux targets on Alpine Linux.

Additionally, this PR allows passing `--libc` option to npm in and it will be used when installing. This allows projects depending on prebuild-install to install desired libc variant.

# Discussion

It could be considered to use explicit `linuxglibc` name instead of just `linux`, just like `linuxmusl`. This would be a backwards-incompatible change and I wanted to make this change as compatible as possible.