### PR TITLE
Upgrade npmlog

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mkdirp-classic": "^0.5.3",
     "napi-build-utils": "^1.0.1",
     "node-abi": "^3.3.0",
-    "npmlog": "^4.0.1",
+    "npmlog": "^5.0.1",
     "pump": "^3.0.0",
     "rc": "^1.2.7",
     "simple-get": "^4.0.0",


### PR DESCRIPTION
Thanks for `prebuild-install`!

This is the smallest possible patch to resolve this snyk security advisory:

  ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908] in ansi-regex@2.1.1

Note that the [latest version of npmlog is v6.0.2](https://github.com/npm/npmlog/blob/main/CHANGELOG.md), but I wanted to make the minimal set of changes to resolve the snyk complaint.