### PR TITLE
Tests: ensure 'npm install' script output can be captured

### DIFF
--- a/log.js
+++ b/log.js
@@ -1,6 +1,4 @@
 const log = require('npmlog')
-const fs = require('fs')
-const path = require('path')
 
 module.exports = function (rc, env) {
   log.heading = 'prebuild-install'
@@ -9,16 +7,6 @@ module.exports = function (rc, env) {
     log.level = 'verbose'
   } else {
     log.level = env.npm_config_loglevel || 'notice'
-  }
-
-  // Temporary workaround for npm 7 which swallows our output
-  if (process.env.npm_config_prebuild_install_logfile) {
-    const fp = path.resolve(process.env.npm_config_prebuild_install_logfile)
-
-    log.on('log', function (msg) {
-      // Only for tests, don't care about performance
-      fs.appendFileSync(fp, [log.heading, msg.level, msg.prefix, msg.message].join(' ') + '\n')
-    })
   }
 
   return log

--- a/test/skip-test.js
+++ b/test/skip-test.js
@@ -33,7 +33,6 @@ test('does not skip download in standalone package', function (t) {
 
 function run (t, mode, args, cb) {
   const addon = tempy.directory()
-  const logfile = path.join(addon, 'prebuild-install.log')
   let cwd = addon
 
   writePackage(addon, {
@@ -62,19 +61,13 @@ function run (t, mode, args, cb) {
     npm_config_addon_binary_host: 'http://localhost:1234',
     npm_config_prefer_offline: 'true',
     npm_config_audit: 'false',
-
-    // Temporary workaround for npm 7 which swallows our output
-    npm_config_prebuild_install_logfile: logfile,
+    npm_config_foreground_scripts: true,
     npm_config_loglevel: 'info'
   })
 
-  exec(npm + ' install', { cwd, env }, function (err) {
+  exec(npm + ' install', { cwd, env }, function (err, stdout, stderr) {
     t.ifError(err, 'no install error')
-
-    fs.readFile(logfile, 'utf8', function (err, data) {
-      t.ifError(err, 'no read error')
-      cb(logs(data))
-    })
+    cb(logs(stderr))
   })
 }
 


### PR DESCRIPTION
Replaces the temporary logfile workaround with the use of the `foreground-scripts` setting, available in npm v7+.

https://docs.npmjs.com/cli/v8/using-npm/config#foreground-scripts

(This should hopefully make removing `npmlog` a tiny bit easier.)