### PR TITLE
Replace use of npmlog dependency with console.error

### DIFF
--- a/log.js
+++ b/log.js
@@ -1,13 +1,33 @@
-const log = require('npmlog')
+const levels = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  notice: 3,
+  http: 4,
+  timing: 5,
+  info: 6,
+  verbose: 7,
+  silly: 8
+}
 
 module.exports = function (rc, env) {
-  log.heading = 'prebuild-install'
+  const level = rc.verbose
+    ? 'verbose'
+    : env.npm_config_loglevel || 'notice'
 
-  if (rc.verbose) {
-    log.level = 'verbose'
-  } else {
-    log.level = env.npm_config_loglevel || 'notice'
+  const logAtLevel = function (messageLevel) {
+    return function (...args) {
+      if (levels[messageLevel] <= levels[level]) {
+        console.error(`prebuild-install ${messageLevel} ${args.join(' ')}`)
+      }
+    }
   }
 
-  return log
+  return {
+    error: logAtLevel('error'),
+    warn: logAtLevel('warn'),
+    http: logAtLevel('http'),
+    info: logAtLevel('info'),
+    level
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "mkdirp-classic": "^0.5.3",
     "napi-build-utils": "^1.0.1",
     "node-abi": "^3.3.0",
-    "npmlog": "^4.0.1",
     "pump": "^3.0.0",
     "rc": "^1.2.7",
     "simple-get": "^4.0.0",


### PR DESCRIPTION
This is a possible approach to address https://github.com/prebuild/prebuild-install/issues/163

The `npmlog` dependency always writes to `stderr` so the use of `console.error()` is consistent with the previous behaviour.

https://github.com/npm/npmlog/blob/7aefa36320a4265f2825f34db29f129f5927f41b/lib/log.js#L12

All existing log message formats and levels remain as before, which takes advantage of existing tests that cover these.

We could remove the concept of levels entirely, but that would have a slightly wider impact and I've not attempted it here.

Closes #163, closes #116.