### PR TITLE
Use sha1, instead of md5

### DIFF
--- a/util.js
+++ b/util.js
@@ -74,7 +74,7 @@ function trimSlashes (str) {
 }
 
 function cachedPrebuild (url) {
-  const digest = crypto.createHash('md5').update(url).digest('hex').slice(0, 6)
+  const digest = crypto.createHash('sha1').update(url).digest('hex').slice(0, 6)
   return path.join(prebuildCache(), digest + '-' + path.basename(url).replace(/[^a-zA-Z0-9.]+/g, '-'))
 }
 

--- a/util.js
+++ b/util.js
@@ -74,7 +74,7 @@ function trimSlashes (str) {
 }
 
 function cachedPrebuild (url) {
-  const digest = crypto.createHash('sha1').update(url).digest('hex').slice(0, 6)
+  const digest = crypto.createHash('sha512').update(url).digest('hex').slice(0, 6)
   return path.join(prebuildCache(), digest + '-' + path.basename(url).replace(/[^a-zA-Z0-9.]+/g, '-'))
 }
 


### PR DESCRIPTION
This allows prebuild-install to be used on fips systems