### PR TITLE
force ipv4 for prebuild requests

### DIFF
--- a/download.js
+++ b/download.js
@@ -40,7 +40,7 @@ function downloadPrebuild (downloadUrl, opts, cb) {
         }
 
         log.http('request', 'GET ' + downloadUrl)
-        const reqOpts = proxy({ url: downloadUrl }, opts)
+        const reqOpts = proxy({ url: downloadUrl, family: 4 }, opts)
 
         if (opts.token) {
           reqOpts.headers = {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scrypted/prebuild-install",
+  "name": "prebuild-install",
   "version": "7.1.2",
   "description": "A command line tool to easily install prebuilt binaries for multiple version of node/iojs on a specific platform",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prebuild-install",
+  "name": "@scrypted/prebuild-install",
   "version": "7.1.2",
   "description": "A command line tool to easily install prebuilt binaries for multiple version of node/iojs on a specific platform",
   "scripts": {


### PR DESCRIPTION
force ipv4 for prebuild request due to simple-get request timeout when encountering broken ipv6 routers

The underlying issue is that when dns resolves to multiple IPs all ips are attempted. ipv6 is tried first, then ipv4. This behavior is known as Happy Eyeballs. https://en.wikipedia.org/wiki/Happy_Eyeballs

For every ip failure, it will emit a timeout event which simple-get interprets as an error and terminate the request (which is still attempting other ips).
https://github.com/feross/simple-get/blob/e7a74115ca9dd28720f186275c5a67df81985426/index.js#L75
Specifically, disabling/ignoring this ipv6 timeout event in simple-get allows the request to succeed on ipv4, and prebuild-install completes successfully.

This timeout event handling may be a bug in either node (since the entire request hasnt timed out, just 1 ip attempt), or a bug in simple-get where it should be more discerning about which request timeout events it should observe. In any case, this is an issue with an end user machines ipv6 network configuration. Expecting binaries be hosted on a ipv4 resolvable address seems reasonable, so that prebuilds have a happy path for successful install. Otherwise it can fall back to host build.

https://nodejs.org/api/net.html#netgetdefaultautoselectfamily

