### PR TITLE
Bump napi-build-utils from 1 to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "github-from-package": "0.0.0",
     "minimist": "^1.2.3",
     "mkdirp-classic": "^0.5.3",
-    "napi-build-utils": "^2.0.0 || ^1.0.1",
+    "napi-build-utils": "^2.0.0",
     "node-abi": "^3.3.0",
     "pump": "^3.0.0",
     "rc": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "github-from-package": "0.0.0",
     "minimist": "^1.2.3",
     "mkdirp-classic": "^0.5.3",
-    "napi-build-utils": "^1.0.1",
+    "napi-build-utils": "^2.0.0 || ^1.0.1",
     "node-abi": "^3.3.0",
     "pump": "^3.0.0",
     "rc": "^1.2.7",


### PR DESCRIPTION
Fixes https://github.com/prebuild/prebuild-install/issues/203.

I don't have a good mechanism to test the changes inside prebuild-install without publishing releases of these packages, but I can test the new version of napi-build-utils in our package and confirm that it detects the correct version of napi.

I tested this in the @mongodb-js/zstd package by installing napi-build-utils@2.0.0 and confirming that it now detects an napi version of 4:

before fix:
```shell
> require('napi-build-utils/package.json').version
'1.0.2'
> require('./package.json').binary
{ napi_versions: [ 4 ] }
> require('napi-build-utils').getBestNapiBuildVersion()
undefined
```

after fix:
```shell
> require('./package.json').binary
{ napi_versions: [ 4 ] }
> require('napi-build-utils/package.json').version
'2.0.0'
> require('napi-build-utils').getBestNapiBuildVersion()
4
```

let met know if there's anything else you'd like in this PR or any additional testing you can think of.  Thanks!