### PR TITLE
docs: fix shield badge for test workflow in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![npm](https://img.shields.io/npm/v/prebuild-install.svg)](https://www.npmjs.com/package/prebuild-install)
 ![Node version](https://img.shields.io/node/v/prebuild-install.svg)
-[![Test](https://img.shields.io/github/workflow/status/prebuild/prebuild-install/Test?label=test)](https://github.com/prebuild/prebuild-install/actions/workflows/test.yml)
+[![Test](https://img.shields.io/github/actions/workflow/status/prebuild/prebuild-install/test.yml?label=test)](https://github.com/prebuild/prebuild-install/actions/workflows/test.yml)
 [![Standard](https://img.shields.io/badge/standard-informational?logo=javascript\&logoColor=fff)](https://standardjs.com)
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
 


### PR DESCRIPTION
Hi, this PR fixes  the deprecated badge on README.

## Before
![Screenshot_20250216-214509](https://github.com/user-attachments/assets/3af66c38-d2ee-4bc0-a6d4-b15603a380f5)

## After
![Screenshot_20250216-214350](https://github.com/user-attachments/assets/2375604e-bcda-4dfa-ba2d-0275145e770b)
