### PR TITLE
[CVE-2025-59343] Update tar-fs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pump": "^3.0.0",
     "rc": "^1.2.7",
     "simple-get": "^4.0.0",
-    "tar-fs": "^2.0.0",
+    "tar-fs": "^2.1.4",
     "tunnel-agent": "^0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Address https://github.com/mafintosh/tar-fs/security/advisories/GHSA-vj76-c3g6-qr5v