### PR TITLE
Fix CVE-2025-59343

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pump": "^3.0.0",
     "rc": "^1.2.7",
     "simple-get": "^4.0.0",
-    "tar-fs": "^2.0.0",
+    "tar-fs": "^2.1.4",
     "tunnel-agent": "^0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The high severity security vulnerability (8.7/10) https://github.com/advisories/GHSA-vj76-c3g6-qr5v was fixed in `tar-fs` v2.1.4, and as such all projects relying on `tar-fs` v2 should pin this version as lowest allowed version.

@vweevers if you have the power to merge this in and kick off a new patch version release, that would be _really good_.